### PR TITLE
wheel for pycocotools, groundingdino

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,5 +1,71 @@
-import launch
 import os
+import platform
+
+import launch
+
+
+def check_system_machine():
+    system = platform.system()
+    machine = platform.machine()
+    return (system, machine) in [('Windows', 'AMD64'), ('Linux', 'x86_64')]
+
+
+def check_python_version(low: int, high: int):
+    ver = platform.python_version_tuple()
+    if int(ver[0]) == 3 and low <= int(ver[1]) <= high:
+        return ver[0] + ver[1]
+    return None
+
+
+def install_pycocotools():
+    base = 'https://github.com/Bing-su/dddetailer/releases/download/pycocotools/'
+    urls = {
+        'Windows': 'pycocotools-2.0.6-cp{ver}-cp{ver}-win_amd64.whl',
+        'Linux': 'pycocotools-2.0.6-cp{ver}-cp{ver}-manylinux_2_17_x86_64.manylinux2014_x86_64.whl',
+    }
+
+    python_version = check_python_version(8, 11)
+    if not check_system_machine() or not python_version:
+        launch.run_pip('install pycocotools', 'sd-webui-ddsd requirement: pycocotools')
+        return
+
+    url = urls[platform.system()].format(ver=python_version)
+    launch.run_pip(f'install {base + url}', 'sd-webui-ddsd requirement: pycocotools')
+
+
+def install_groundingdino():
+    import torch
+    from packaging.version import parse
+
+    # torch_version: '1.13.1' or '2.0.0' or ...
+    torch_version = parse(torch.__version__).base_version
+    # cuda_version: '117' or '118' or 'None'
+    cuda_version = torch.version.cuda.replace('.', '')
+    python_version = check_python_version(9, 10)
+
+    if (
+        not check_system_machine()
+        or (torch_version, cuda_version)
+        not in [('1.13.1', '117'), ('2.0.0', '117'), ('2.0.0', '118')]
+        or not python_version
+    ):
+        launch.run_pip('install groundingdino', 'sd-webui-ddsd requirement: groundingdino')
+        return
+
+    system = 'win' if platform.system() == 'Windows' else 'linux'
+    machine = 'amd64' if platform.machine() == 'AMD64' else 'x86_64'
+
+    url = 'https://github.com/Bing-su/GroundingDINO/releases/download/wheel-0.1.0/groundingdino-0.1.0+torch{torch}.cu{cuda}-cp{py}-cp{py}-{system}_{machine}.whl'
+    url = url.format(
+        torch=torch_version,
+        cuda=cuda_version,
+        py=python_version,
+        system=system,
+        machine=machine,
+    )
+
+    launch.run_pip(f'install {url}', 'sd-webui-ddsd requirement: groundingdino')
+
 
 current_dir = os.path.dirname(os.path.realpath(__file__))
 req_file = os.path.join(current_dir, 'requirements.txt')
@@ -9,9 +75,12 @@ with open(req_file) as file:
         lib = lib.strip()
         if not launch.is_installed(lib):
             lib_fin = lib
-            if lib == 'groundingdino':
-                lib_fin = 'git+https://github.com/IDEA-Research/GroundingDINO'
-            launch.run_pip(
-                f'install {lib_fin}',
-                f'sd-webui-ddsd requirement: {lib_fin}'
-            )
+            if lib == 'pycocotools':
+                install_pycocotools()
+            elif lib == 'groundingdino':
+                install_groundingdino()
+            else:
+                launch.run_pip(
+                    f'install {lib_fin}',
+                    f'sd-webui-ddsd requirement: {lib_fin}'
+                )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+pycocotools
 segment_anything
 groundingdino
 scipy


### PR DESCRIPTION
안녕하세요. [dddetailer](https://github.com/Bing-su/dddetailer)를 관리하고 있는 빙수라고 합니다.

이 PR은 groundingdino 설치를 편하게 해주는게 목적입니다.

1. groundingdino의 의존성중 하나인 pycocotools는 윈도우즈에서는 c++ 빌드툴을, 리눅스에서는 gcc를 필요로 합니다.
2. groundingdino는 설치한 torch와 같은 버전의 cuda를 설치해야 합니다.

때문에 설치가 힘드니 미리 빌드해왔습니다.

pycocotools는 dddetailer에서 쓰던걸 그대로 가져왔습니다 (https://github.com/Bing-su/dddetailer/releases/tag/pycocotools)
groundingdino는 원본을 포크해서, github actions로 빌드했고, (https://github.com/Bing-su/GroundingDINO/blob/main/.github/workflows/build_wheel.yml)
여기서 해당 토치 버전에서 사용할 수 있는 모든 기기에 대한 플래그를 다 집어넣었으니 어떤 그래픽카드에서도 돌아갈 것으로 기대하고 있습니다.

이 방법으로 편하게 설치가 되는 환경은
1. python == 3.9 또는 3.10
2. torch == 1.13.1+cu117 (webui 기본설정), torch==2.0.0+cu117 (런포드), torch==2.0.0+cu118 (코랩 등)
이며, 이외의 환경에선 기존처럼 소스코드에서 빌드하게 되어있습니다.

저는 윈도우즈에서 RTX3070, python 3.10, torch 2.0.0+cu118을 사용하고 있고, 이 환경에서 정상작동하는 것을 확인했습니다.
